### PR TITLE
fix: bad call or return

### DIFF
--- a/games/IGameProvider.hpp
+++ b/games/IGameProvider.hpp
@@ -32,5 +32,5 @@ public:
    *
    * @return Created game instance
    */
-  virtual std::shared_ptr<game::IGame> createInstance(void) = 0;
+  virtual std::shared_ptr<shared::games::IGame> createInstance(void) = 0;
 };

--- a/games/export.cpp.example
+++ b/games/export.cpp.example
@@ -14,7 +14,7 @@ extern "C" {
         return shared::types::LibraryType::GAME;
     }
 
-    std::shared_ptr<shared::games::IGameProvider> SHARED_GRAPHICS_FACTORY_LOADER_NAME(void)
+    std::shared_ptr<shared::games::IGameProvider> SHARED_GAME_PROVIDER_LOADER_NAME(void)
     {
         return std::make_shared<GameClass>(...)
     }

--- a/games/export.cpp.example
+++ b/games/export.cpp.example
@@ -6,7 +6,7 @@
 */
 
 #include "IGame.hpp"
-#include "../types/LibraryType.hpp"
+#include "../types/Libraries.hpp"
 
 extern "C" {
     shared::types::LibraryType SHARED_LIBRARY_TYPE_GETTER_NAME(void)

--- a/games/export.cpp.example
+++ b/games/export.cpp.example
@@ -14,7 +14,7 @@ extern "C" {
         return shared::types::LibraryType::GAME;
     }
 
-    std::shared_ptr<shared::games::IGame> SHARED_GRAPHICS_FACTORY_LOADER_NAME(void)
+    std::shared_ptr<shared::games::IGameProvider> SHARED_GRAPHICS_FACTORY_LOADER_NAME(void)
     {
         return std::make_shared<GameClass>(...)
     }

--- a/graphics/IGraphicsProvider.hpp
+++ b/graphics/IGraphicsProvider.hpp
@@ -28,7 +28,7 @@ class shared::graphics::IGraphicsProvider {
      *
      * @return Manifest of the graphics library
      */
-    virtual const GameManifest &getManifest(void) const noexcept = 0;
+    virtual const GraphicsManifest &getManifest(void) const noexcept = 0;
 
     /**
      * @brief Create a renderer object

--- a/graphics/export.cpp.example
+++ b/graphics/export.cpp.example
@@ -14,7 +14,7 @@ extern "C" {
         return shared::types::LibraryType::GRAPHIC;
     }
 
-    std::shared_ptr<shared::graphics::IGraphicsFactory> SHARED_GAME_PROVIDER_LOADER_NAME(void)
+    std::shared_ptr<shared::graphics::IGraphicsProvider> SHARED_GAME_PROVIDER_LOADER_NAME(void)
     {
         return std::make_shared<RendererClass>(...);
     }

--- a/graphics/export.cpp.example
+++ b/graphics/export.cpp.example
@@ -14,7 +14,7 @@ extern "C" {
         return shared::types::LibraryType::GRAPHIC;
     }
 
-    std::shared_ptr<shared::graphics::IGraphicsProvider> SHARED_GAME_PROVIDER_LOADER_NAME(void)
+    std::shared_ptr<shared::graphics::IGraphicsProvider> SHARED_GRAPHICS_PROVIDER_LOADER_NAME(void)
     {
         return std::make_shared<RendererClass>(...);
     }

--- a/types/Libraries.hpp
+++ b/types/Libraries.hpp
@@ -13,7 +13,8 @@
 #define SHARED_GAME_PROVIDER_LOADER_NAME arcadeLibGetGameProvider
 #define SHARED_GRAPHICS_PROVIDER_LOADER_NAME arcadeLibGetGraphicsProvider
 #define SHARED_LIBRARY_TYPE_GETTER_NAME arcadeLibGetType
-#define SHARED_STRINGIFY(x) #x
+#define STRINGIFY(x) #x
+#define SHARED_STRINGIFY(x) STRINGIFY(x)
 
 namespace shared::types
 {


### PR DESCRIPTION
## Changes made

I have to fix:

    return of getManifest function in IGraphicsProvider
    interface return in shared_ptr of createInstance function in IGameProvider
    include in export.cpp.example in games
    SHARED_STRINGIFY in Libraries.hpp


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: because it's just a fix of interface
- [ ] I need help with writing tests
