### PR TITLE
Fix IComponent entity getter and recursive include loop

### DIFF
--- a/games/components/IComponent.hpp
+++ b/games/components/IComponent.hpp
@@ -45,5 +45,5 @@ public:
    *
    * @return Entity of the component
    */
-  virtual std::shared_ptr<entity::IEntity> getEntity() noexcept = 0;
+  virtual const entity::IEntity &getEntity() noexcept = 0;
 };

--- a/types/Libraries.hpp
+++ b/types/Libraries.hpp
@@ -23,7 +23,7 @@ namespace shared::types
     GRAPHIC,
   } LibraryType;
 
-  typedef std::shared_ptr<shared::games::IGameProvider> (*GameProvider)(void);
-  typedef std::shared_ptr<shared::graphics::IGraphicsProvider> (*GraphicsProvider)(void);
+  typedef std::shared_ptr<games::IGameProvider> (*GameProvider)(void);
+  typedef std::shared_ptr<graphics::IGraphicsProvider> (*GraphicsProvider)(void);
   typedef LibraryType (*LibraryTypeGetter)(void);
 }

--- a/types/types.hpp
+++ b/types/types.hpp
@@ -9,4 +9,3 @@
 
 #include "Vector.hpp"
 #include "UUId.hpp"
-#include "Libraries.hpp"


### PR DESCRIPTION
## Changes made

Fixed recursive include loop in the types.hpp

Fix IComponent entity getter to return a reference to the IEntity instead of a shared pointer

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: because arcade sucks
- [ ] I need help with writing tests
