### PR TITLE
Fix events not being able to be instantiated

### DIFF
--- a/graphics/events/Event.hpp
+++ b/graphics/events/Event.hpp
@@ -2,14 +2,14 @@
 ** EPITECH PROJECT, 2024
 ** arcade-shared
 ** File description:
-** IEvent
+** Event
 */
 
 #pragma once
 
 namespace shared::graphics::events
 {
-  class IEvent;
+  class Event;
 
   typedef enum
   {
@@ -23,13 +23,14 @@ namespace shared::graphics::events
   } EventType;
 }
 
-class shared::graphics::events::IEvent
+class shared::graphics::events::Event
 {
   public:
-    virtual ~IEvent() = default;
+    Event(EventType type) : type(type) {}
+    virtual ~Event() = default;
 
     /**
      * @brief Event type
      */
-    virtual const EventType getType() const noexcept = 0;
+    const EventType type;
 };

--- a/graphics/events/Event.hpp
+++ b/graphics/events/Event.hpp
@@ -27,7 +27,6 @@ class shared::graphics::events::Event
 {
   public:
     Event(EventType type) : type(type) {}
-    virtual ~Event() = default;
 
     /**
      * @brief Event type

--- a/graphics/events/key/AKeyEvent.hpp
+++ b/graphics/events/key/AKeyEvent.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "../IEvent.hpp"
+#include "../Event.hpp"
 
 namespace shared::graphics::events {
   template<EventType T>
@@ -47,18 +47,9 @@ namespace shared::graphics::events {
 }
 
 template<shared::graphics::events::EventType T>
-class shared::graphics::events::AKeyEvent: public IEvent {
+class shared::graphics::events::AKeyEvent: public Event {
   public:
     ~AKeyEvent() = default;
-
-    /**
-     * @brief Event type
-     *
-     */
-    const EventType getType(void) const noexcept
-    {
-      return this->_type;
-    }
 
     /**
      * @brief Key code content
@@ -79,7 +70,7 @@ class shared::graphics::events::AKeyEvent: public IEvent {
     }
 
   protected:
-    AKeyEvent(KeyType keyType, KeyCode keyCode) : _keyType(keyType), _keyCode(keyCode) {}
+    AKeyEvent(KeyType keyType, KeyCode keyCode) : Event(T), _keyType(keyType), _keyCode(keyCode) {}
 
     EventType _type = T;
     KeyType   _keyType;

--- a/graphics/events/mouse/AMouseEvent.hpp
+++ b/graphics/events/mouse/AMouseEvent.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include "../../../types/types.hpp"
-#include "../IEvent.hpp"
+#include "../Event.hpp"
 
 namespace shared::graphics::events
 {
@@ -22,18 +22,10 @@ namespace shared::graphics::events
 }
 
 template<shared::graphics::events::EventType T>
-class shared::graphics::events::AMouseEvent : public IEvent
+class shared::graphics::events::AMouseEvent : public Event
 {
    public:
     ~AMouseEvent() = default;
-
-    /**
-     * @brief Event type
-     *
-     */
-    const EventType getType(void) const noexcept {
-      return T;
-    }
 
     /**
      * @brief Mouse position
@@ -44,7 +36,7 @@ class shared::graphics::events::AMouseEvent : public IEvent
     }
 
   protected:
-    AMouseEvent(types::Vector2f position): _position(position) {}
+    AMouseEvent(types::Vector2f position): Event(T), _position(position) {}
 
     types::Vector2f _position;
 };

--- a/graphics/events/window/WindowCloseEvent.hpp
+++ b/graphics/events/window/WindowCloseEvent.hpp
@@ -7,23 +7,14 @@
 
 #pragma once
 
-#include "../IEvent.hpp"
+#include "../Event.hpp"
 
 namespace shared::graphics::events {
   class WindowCloseEvent;
 }
 
-class shared::graphics::events::WindowCloseEvent: public IEvent {
+class shared::graphics::events::WindowCloseEvent: public Event {
   public:
-    WindowCloseEvent() = default;
+    WindowCloseEvent() : Event(WINDOW_CLOSE) {};
     ~WindowCloseEvent() = default;
-
-    /**
-     * @brief Event type
-     *
-     */
-    const EventType getType() const noexcept
-    {
-      return WINDOW_CLOSE;
-    }
 };

--- a/graphics/events/window/WindowResizeEvent.hpp
+++ b/graphics/events/window/WindowResizeEvent.hpp
@@ -7,26 +7,17 @@
 
 #pragma once
 
-#include "../IEvent.hpp"
+#include "../Event.hpp"
 #include "../../../types/types.hpp"
 
 namespace shared::graphics::events {
   class WindowResizeEvent;
 }
 
-class shared::graphics::events::WindowResizeEvent: public IEvent {
+class shared::graphics::events::WindowResizeEvent: public Event {
   public:
-    WindowResizeEvent(types::Vector2u newSize) : _newSize(newSize) {}
+    WindowResizeEvent(types::Vector2u newSize) : Event(WINDOW_RESIZE), _newSize(newSize) {}
     ~WindowResizeEvent() = default;
-
-    /**
-     * @brief Event type
-     *
-     */
-    const EventType getType() const noexcept
-    {
-      return WINDOW_RESIZE;
-    }
 
     /**
      * @brief Get the new window size

--- a/graphics/window/IWindow.hpp
+++ b/graphics/window/IWindow.hpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "../events/IEvent.hpp"
+#include "../events/Event.hpp"
 #include "../../types/types.hpp"
 #include "../types/EntityProps.hpp"
 
@@ -150,5 +150,5 @@ class shared::graphics::IWindow {
      * but make another call `B` (directly after call `A`) `eventsB`
      * will result to an empty vector
      */
-    virtual std::vector<events::IEvent> getEvents(void) = 0;
+    virtual std::vector<events::Event> getEvents(void) = 0;
 };


### PR DESCRIPTION
## Changes made

Fix events not being able to be instantiated due to the IEvent class being purely virtual, thus making the getEvents() method in the IWindow interface unusable.

Corrected that by making a base class Event, that can be easily instantiated

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: testing is doubting
- [ ] I need help with writing tests
