### PR TITLE
fix(graphics): add missing ITexture namespace

### DIFF
--- a/graphics/ITexture.hpp
+++ b/graphics/ITexture.hpp
@@ -11,7 +11,7 @@ namespace shared::graphics {
     class ITexture;
 }
 
-class ITexture {
+class shared::graphics::ITexture {
   public:
     virtual ~ITexture() = default;
 };


### PR DESCRIPTION
## Changes made

I've added missing namespace `shared::graphics` to `ITexture` interface.