### PR TITLE
refactor(grpahics): exceptions extends now of std::exception

### DIFF
--- a/graphics/exceptions/IGraphicsException.hpp
+++ b/graphics/exceptions/IGraphicsException.hpp
@@ -7,13 +7,13 @@
 
 #pragma once
 
-#include <string>
+#include <exception>
 
 namespace shared::graphics::exceptions {
     class IGraphicsException;
 }
 
-class shared::graphics::exceptions::IGraphicsException {
+class shared::graphics::exceptions::IGraphicsException: public std::exception {
 public:
     virtual ~IGraphicsException() = default;
 
@@ -21,11 +21,11 @@ public:
      * @brief Get error details
      * @return String containing error details
      */
-    virtual const std::string &what() const noexcept = 0;
+    virtual const char *what() const noexcept = 0;
 
     /**
      * @brief Get error location
      * @return String containing error location
      */
-    virtual const std::string &where() const noexcept = 0;
+    virtual const char *where() const noexcept = 0;
 };

--- a/graphics/exceptions/IGraphicsException.hpp
+++ b/graphics/exceptions/IGraphicsException.hpp
@@ -15,13 +15,7 @@ namespace shared::graphics::exceptions {
 
 class shared::graphics::exceptions::IGraphicsException: public std::exception {
 public:
-    virtual ~IGraphicsException() = default;
-
-    /**
-     * @brief Get error details
-     * @return String containing error details
-     */
-    virtual const char *what() const noexcept = 0;
+    virtual ~IGraphicsException() override = default;
 
     /**
      * @brief Get error location

--- a/graphics/exceptions/IGraphicsException.hpp
+++ b/graphics/exceptions/IGraphicsException.hpp
@@ -15,8 +15,6 @@ namespace shared::graphics::exceptions {
 
 class shared::graphics::exceptions::IGraphicsException: public std::exception {
 public:
-    virtual ~IGraphicsException() override = default;
-
     /**
      * @brief Get error location
      * @return String containing error location


### PR DESCRIPTION
## Changes made

It's a better practice to make any exception a extension of `std::exception`. It was not the case one `IGraphicsException` but now it is.
