### PR TITLE
fix: enum conflicts between TextComponent and KeyboardComponent

### DIFF
--- a/games/components/IKeyboardComponent.hpp
+++ b/games/components/IKeyboardComponent.hpp
@@ -12,7 +12,11 @@
 
 namespace shared::games::components {
   class IKeyboardComponent;
+}
 
+class shared::games::components::IKeyboardComponent: public virtual IComponent
+{
+public:
   typedef enum
   {
     CONTROL, // Control key (`Ctrl`, `Shift`, `Alt`)
@@ -50,11 +54,7 @@ namespace shared::games::components {
     KeyCode code; // Key code. Interpretation depends on the type
     KeyType type; // Type of the key
   } KeyData;
-}
 
-class shared::games::components::IKeyboardComponent: public virtual IComponent
-{
-public:
   virtual ~IKeyboardComponent() = default;
 
   /**

--- a/games/components/ITextComponent.hpp
+++ b/games/components/ITextComponent.hpp
@@ -13,11 +13,14 @@
 
 namespace shared::games::components {
     class ITextComponent;
+}
 
+class shared::games::components::ITextComponent : public virtual IDisplayableComponent {
+public:
     typedef enum {
-        TEXT_LEFT,
+        LEFT,
         CENTER,
-        TEXT_RIGHT
+        RIGHT
     } TextAlign;
 
     typedef enum {
@@ -38,10 +41,7 @@ namespace shared::games::components {
         TextFontProps font;                 // Font of the text
         types::Color color;                 // Color of the text
     } TextProps;
-}
 
-class shared::games::components::ITextComponent : public virtual IDisplayableComponent {
-public:
     virtual ~ITextComponent() = default;
 
     /**

--- a/games/components/ITextComponent.hpp
+++ b/games/components/ITextComponent.hpp
@@ -15,9 +15,9 @@ namespace shared::games::components {
     class ITextComponent;
 
     typedef enum {
-        LEFT,
+        TEXT_LEFT,
         CENTER,
-        RIGHT
+        TEXT_RIGHT
     } TextAlign;
 
     typedef enum {


### PR DESCRIPTION
## Changes made

Change enum names to get rid of this conflict when importing both KeyboardComponent and TextComponent

![Capture d'écran 2024-03-28 212246](https://github.com/G-Epitech/MAYBDF-ArcadeShared/assets/114678687/c31c61bb-7207-44e3-b571-9d8006703d37)


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
