### PR TITLE
refactor(text): avoid code duplication for text

### DIFF
--- a/games/components/ITextComponent.hpp
+++ b/games/components/ITextComponent.hpp
@@ -10,6 +10,7 @@
 #include "IDisplayableComponent.hpp"
 #include "../../types/Vector.hpp"
 #include "../../types/Color.hpp"
+#include "../../types/Text.hpp"
 
 namespace shared::games::components {
     class ITextComponent;
@@ -17,17 +18,6 @@ namespace shared::games::components {
 
 class shared::games::components::ITextComponent : public virtual IDisplayableComponent {
 public:
-    typedef enum {
-        LEFT,
-        CENTER,
-        RIGHT
-    } TextAlign;
-
-    typedef enum {
-        BOTTOM,
-        MIDDLE,
-        TOP
-    } TextVerticalAlign;
 
     typedef struct {
         std::string path;       // Path of the font

--- a/graphics/types/TextProps.hpp
+++ b/graphics/types/TextProps.hpp
@@ -13,21 +13,11 @@
 #include "../IFont.hpp"
 #include "../../types/Vector.hpp"
 #include "../../types/Color.hpp"
+#include "../../types/Text.hpp"
 
 using namespace shared::types;
 
 namespace shared::graphics {
-    typedef enum {
-        LEFT,
-        CENTER,
-        RIGHT
-    } TextAlign;
-
-    typedef enum {
-        BOTTOM,
-        MIDDLE,
-        TOP
-    } TextVerticalAlign;
 
     typedef struct {
         std::shared_ptr<IFont> font;        // Font of the text

--- a/types/Text.hpp
+++ b/types/Text.hpp
@@ -1,0 +1,25 @@
+/*
+** EPITECH PROJECT, 2024
+** arcade_shared
+** File description:
+** Text
+*/
+
+#pragma once
+
+#include <iostream>
+#include "./Vector.hpp"
+
+namespace shared::types {
+    typedef enum {
+        LEFT,
+        CENTER,
+        RIGHT
+    } TextAlign;
+
+    typedef enum {
+        BOTTOM,
+        MIDDLE,
+        TOP
+    } TextVerticalAlign;
+}


### PR DESCRIPTION
## Changes made

I refactor enum in order to directly pass them between libraries.

![image](https://github.com/G-Epitech/MAYBDF-ArcadeShared/assets/71837212/b4cba05f-7850-4082-95df-09e02146194c)


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: _Don't care_
- [ ] I need help with writing tests
