### PR TITLE
refactor(component): refactor position component to spatial component (add getSize)

### DIFF
--- a/games/components/ICollidableComponent.hpp
+++ b/games/components/ICollidableComponent.hpp
@@ -8,14 +8,14 @@
 #pragma once
 
 #include "../IGame.hpp"
-#include "IPositionComponent.hpp"
+#include "ISpatialComponent.hpp"
 #include "../../types/Vector.hpp"
 
 namespace shared::games::components {
   class ICollidableComponent;
 }
 
-class shared::games::components::ICollidableComponent: public virtual IPositionComponent
+class shared::games::components::ICollidableComponent: public virtual ISpatialComponent
 {
 public:
   virtual ~ICollidableComponent() = default;

--- a/games/components/ICollidableComponent.hpp
+++ b/games/components/ICollidableComponent.hpp
@@ -8,14 +8,14 @@
 #pragma once
 
 #include "../IGame.hpp"
-#include "ISpatialComponent.hpp"
+#include "IPositionableComponent.hpp"
 #include "../../types/Vector.hpp"
 
 namespace shared::games::components {
   class ICollidableComponent;
 }
 
-class shared::games::components::ICollidableComponent: public virtual ISpatialComponent
+class shared::games::components::ICollidableComponent: public virtual IPositionableComponent
 {
 public:
   virtual ~ICollidableComponent() = default;

--- a/games/components/IComponent.hpp
+++ b/games/components/IComponent.hpp
@@ -13,9 +13,10 @@ namespace shared::games::components {
     typedef enum {
       TEXTURE,
       TEXT,
+      DISPLAYABLE,
       SOUND,
       COLLIDABLE,
-      POSITION,
+      SPATIAL,
       KEYBOARD
     } ComponentType;
 

--- a/games/components/IDisplayableComponent.hpp
+++ b/games/components/IDisplayableComponent.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "ISpatialComponent.hpp"
+#include "IPositionableComponent.hpp"
 #include "../IGame.hpp"
 #include "../../types/Vector.hpp"
 
@@ -15,7 +15,7 @@ namespace shared::games::components {
     class IDisplayableComponent;
 }
 
-class shared::games::components::IDisplayableComponent : public virtual ISpatialComponent {
+class shared::games::components::IDisplayableComponent : public virtual IPositionableComponent {
 public:
     virtual ~IDisplayableComponent() = default;
 

--- a/games/components/IDisplayableComponent.hpp
+++ b/games/components/IDisplayableComponent.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "IPositionComponent.hpp"
+#include "ISpatialComponent.hpp"
 #include "../IGame.hpp"
 #include "../../types/Vector.hpp"
 
@@ -15,15 +15,9 @@ namespace shared::games::components {
     class IDisplayableComponent;
 }
 
-class shared::games::components::IDisplayableComponent : public virtual IPositionComponent {
+class shared::games::components::IDisplayableComponent : public virtual ISpatialComponent {
 public:
     virtual ~IDisplayableComponent() = default;
-
-    /**
-     * @brief Get size of the entity (tiles)
-     *
-     */
-    virtual Vector2u &getSize() noexcept = 0;
 
     /**
      * @brief Get Z index that is usefull for display prioroty

--- a/games/components/IPositionableComponent.hpp
+++ b/games/components/IPositionableComponent.hpp
@@ -2,7 +2,7 @@
 ** EPITECH PROJECT, 2024
 ** arcade-shared
 ** File description:
-** ISpatialComponent
+** IPositionableComponent
 */
 
 #pragma once
@@ -11,13 +11,13 @@
 #include "../../types/Vector.hpp"
 
 namespace shared::games::components {
-  class ISpatialComponent;
+  class IPositionableComponent;
 }
 
-class shared::games::components::ISpatialComponent: public virtual IComponent
+class shared::games::components::IPositionableComponent: public virtual IComponent
 {
   public:
-    virtual ~ISpatialComponent() = default;
+    virtual ~IPositionableComponent() = default;
 
     /**
      * @brief Get position of the entity (tiles)

--- a/games/components/ISpatialComponent.hpp
+++ b/games/components/ISpatialComponent.hpp
@@ -2,7 +2,7 @@
 ** EPITECH PROJECT, 2024
 ** arcade-shared
 ** File description:
-** IPositionComponent
+** ISpatialComponent
 */
 
 #pragma once
@@ -11,17 +11,23 @@
 #include "../../types/Vector.hpp"
 
 namespace shared::games::components {
-  class IPositionComponent;
+  class ISpatialComponent;
 }
 
-class shared::games::components::IPositionComponent: public virtual IComponent
+class shared::games::components::ISpatialComponent: public virtual IComponent
 {
   public:
-    virtual ~IPositionComponent() = default;
+    virtual ~ISpatialComponent() = default;
 
     /**
      * @brief Get position of the entity (tiles)
      *
      */
     virtual types::Vector2i &getPosition(void) noexcept = 0;
+
+    /**
+     * @brief Get size of the entity (tiles)
+     *
+     */
+    virtual types::Vector2i &getSize(void) noexcept = 0;
 };


### PR DESCRIPTION
## Changes made

I updated IPositionComponent to ISpatialComponent. This refactor add the getSize() methods to ISpatialComponent. This allow us to get the size of the entity when we check collisions.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: _NOP_
- [ ] I need help with writing tests
