### PR TITLE
fix: getSize return value vector type

### DIFF
--- a/games/components/IPositionableComponent.hpp
+++ b/games/components/IPositionableComponent.hpp
@@ -29,5 +29,5 @@ class shared::games::components::IPositionableComponent: public virtual ICompone
      * @brief Get size of the entity (tiles)
      *
      */
-    virtual types::Vector2i &getSize(void) noexcept = 0;
+    virtual types::Vector2u &getSize(void) noexcept = 0;
 };


### PR DESCRIPTION
## Changes made

I updated return type from getSize method of IPositionableComponent.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
