### PR TITLE
fix: remove useless reference of shared ptr for game events

### DIFF
--- a/games/components/ICollidableComponent.hpp
+++ b/games/components/ICollidableComponent.hpp
@@ -25,5 +25,5 @@ public:
    * @param ctx Context of the game
    * @param target Target entity
    */
-  virtual void onCollide(std::shared_ptr<IGame> &ctx, std::shared_ptr<ICollidableComponent> target) = 0;
+  virtual void onCollide(std::shared_ptr<IGame> ctx, std::shared_ptr<ICollidableComponent> target) = 0;
 };

--- a/games/components/IDisplayableComponent.hpp
+++ b/games/components/IDisplayableComponent.hpp
@@ -29,17 +29,17 @@ public:
      * @brief On click event handler for the entity
      * @param ctx Context of the game
      */
-    virtual void onMousePress(std::shared_ptr <IGame> &ctx) = 0;
+    virtual void onMousePress(std::shared_ptr <IGame> ctx) = 0;
 
     /**
      * @brief On release event handler for the entity
      * @param ctx Context of the game
      */
-    virtual void onMouseRelease(std::shared_ptr <IGame> &ctx) = 0;
+    virtual void onMouseRelease(std::shared_ptr <IGame> ctx) = 0;
 
     /**
      * @brief On hover event handler for the entity
      * @param ctx Context of the game
      */
-    virtual void onMouseHover(std::shared_ptr <IGame> &ctx) = 0;
+    virtual void onMouseHover(std::shared_ptr <IGame> ctx) = 0;
 };

--- a/games/components/IKeyboardComponent.hpp
+++ b/games/components/IKeyboardComponent.hpp
@@ -62,12 +62,12 @@ public:
    * @param ctx Context of the game
    * @param keyData Key data of key pressed
    */
-  virtual void onKeyPress(std::shared_ptr<IGame> &ctx, KeyData keyData) = 0;
+  virtual void onKeyPress(std::shared_ptr<IGame> ctx, KeyData keyData) = 0;
 
   /**
    * @brief On key release event handler for the entity
    * @param ctx Context of the game
    * @param keyData Key data of key released
    */
-  virtual void onKeyRelease(std::shared_ptr<IGame> &ctx, KeyData keyData) = 0;
+  virtual void onKeyRelease(std::shared_ptr<IGame> ctx, KeyData keyData) = 0;
 };

--- a/games/components/IPositionableComponent.hpp
+++ b/games/components/IPositionableComponent.hpp
@@ -23,11 +23,11 @@ class shared::games::components::IPositionableComponent: public virtual ICompone
      * @brief Get position of the entity (tiles)
      *
      */
-    virtual types::Vector2i &getPosition(void) noexcept = 0;
+    virtual types::Vector2i &getPosition() noexcept = 0;
 
     /**
      * @brief Get size of the entity (tiles)
      *
      */
-    virtual types::Vector2u &getSize(void) noexcept = 0;
+    virtual types::Vector2u &getSize() noexcept = 0;
 };

--- a/games/components/ISoundComponent.hpp
+++ b/games/components/ISoundComponent.hpp
@@ -34,28 +34,28 @@ public:
    *
    * @return Sound path
    */
-  virtual const std::string &getPath(void) const noexcept = 0;
+  virtual const std::string &getPath() const noexcept = 0;
 
   /**
    * @brief Get state of the sound
    *
    * @return Sound state
    */
-  virtual SoundState &getState(void) noexcept = 0;
+  virtual SoundState &getState() noexcept = 0;
 
   /**
    * @brief Get volume of the sound
    *
    * @return Sound volume
    */
-  virtual SoundVolume &getVolume(void) noexcept = 0;
+  virtual SoundVolume &getVolume() noexcept = 0;
 
   /**
    * @brief Get loop of the sound
    *
    * @return Sound loop
    */
-  virtual bool &getLoop(void) noexcept = 0;
+  virtual bool &getLoop() noexcept = 0;
 
   /**
    * @brief On state change event handler for the component
@@ -63,5 +63,5 @@ public:
    * @param ctx Context of the game
    * @param state New state of the sound
    */
-  virtual void onStateChange(std::shared_ptr<IGame> &ctx, SoundState state) = 0;
+  virtual void onStateChange(std::shared_ptr<IGame> ctx, SoundState state) = 0;
 };


### PR DESCRIPTION
## Changes made

I removed useless reference of ctx (game) for events because of the new usage of shared_ptr (it was supposed to be used for unique_ptr but useless and no-code friendly now)